### PR TITLE
more types + auth

### DIFF
--- a/src/ImageEndpoint.ts
+++ b/src/ImageEndpoint.ts
@@ -13,13 +13,14 @@ class ImageEndpoint {
     }
 
     /**
-     * @param {ImageEndpointType} type - The type of image to get. Current types: hass, hmidriff, pgif, 4k, hentai, holo, hneko, neko, hkitsune, kemonomimi, anal, hanal, gonewild, kanna, ass, pussy, thigh, hthigh, gah, coffee, food, cosplay, paizuri, tentacle.
+     * @param {ImageEndpointType} type - The type of image to get. Current types: hass, hmidriff, pgif, 4k, hentai, holo, hneko, neko, hkitsune, kemonomimi, anal, hanal, gonewild, kanna, ass, pussy, thigh, hthigh, gah, coffee, food, paizuri, tentacle. Token required types: cosplay, swimsuit
      * @returns {(Promise<String | void>)} Image URL
      */
     public async getImage(type: ImageEndpointType): Promise<String | void> {
         try {
             const { body } = await this.client.request
                 .get(`${this.client.baseURL}image`)
+                .set("Authorization", this.client.token.toString())
                 .query({
                     type
                 });

--- a/src/NekoBot.ts
+++ b/src/NekoBot.ts
@@ -10,8 +10,9 @@ import { ImageGeneration } from "./ImageGeneration";
 class NekoBot {
     public version: String;
     public baseURL: String;
+    public token: String;
     public request: request.SuperAgentStatic;
-    constructor() {
+    constructor(token: String | "") {
         /**
          * Lib version
          * @type {String}
@@ -22,6 +23,11 @@ class NekoBot {
          * @type {String}
          */
         this.baseURL = "https://nekobot.xyz/api/";
+        /**
+         * API Token
+         * @type {String}
+         */
+        this.token = token;
         /**
          * Http client
          * @type {request.SuperAgentStatic}

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -22,4 +22,5 @@ export type ImageEndpointType =
     | "food"
     | "cosplay"
     | "paizuri"
-    | "tentacle";
+    | "tentacle"
+    | "swimsuit";


### PR DESCRIPTION
Not sure what the difference is with `String` and `string` but I think using `.toString()` on a `String` makes it usable as a header key as it compiles uwu